### PR TITLE
Write actual value to GPIO pin instead of the beautified value

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ GPIOOnOffAccessory.prototype.writeGPIO = function(value, callback)
 {
   let gpioValue = this.characteristicToGPIO(value);
   this.log(`Writing Characteristic value ${value} as ${gpioValue}`);
-  this.sensor.write(gpioValue, err =>
+  this.sensor.write(value, err =>
   {
     if (err)
       callback(err);


### PR DESCRIPTION
When writing to the GPIO pin the value to be printed was sent instead of the actual 1/0 value.

This fixes ISSUE #2.